### PR TITLE
Update OmniAuth strategy to include User information.

### DIFF
--- a/lib/omniauth/strategies/digitalocean.rb
+++ b/lib/omniauth/strategies/digitalocean.rb
@@ -1,5 +1,4 @@
 require 'omniauth-oauth2'
-require 'multi_json'
 
 module OmniAuth
   module Strategies
@@ -12,6 +11,7 @@ module OmniAuth
       AUTHENTICATION_PARAMETERS = %w(display state scope)
       BASE_URL = "https://cloud.digitalocean.com"
 
+      # Name of this strategy
       option :name, :digitalocean
 
       unless OmniAuth.config.test_mode
@@ -38,6 +38,10 @@ module OmniAuth
         access_token.params['info']
       end
 
+      extra do
+        raw_info.parsed['account']
+      end
+
       # Hook useful for appending parameters into the auth url before sending
       # to provider.
       def request_phase
@@ -48,6 +52,13 @@ module OmniAuth
       # request from provider.
       def callback_phase
         super
+      end
+
+      #
+      # Retrieves the information about the user
+      #
+      def raw_info
+        @raw_info ||= access_token.get('v2/account')
       end
 
       ##

--- a/spec/omniauth/strategies/digitalocean_spec.rb
+++ b/spec/omniauth/strategies/digitalocean_spec.rb
@@ -22,7 +22,18 @@ describe OmniAuth::Strategies::Digitalocean do
         }
       }
     }
-    let(:access_token) { double('AccessToken', params: response_params) }
+    let(:account_response) {
+      { 'account' =>
+        {
+          'droplet_limit' => 25,
+          'email' => 'foo@example.com',
+          'uuid' => 'b6fc48dbf6d990634ce5f3c78dc9851e757381ef',
+          'email_verified' => true
+        }
+      }
+    }
+    let(:account_json) { double(:json, parsed: account_response) }
+    let(:access_token) { double('AccessToken', params: response_params, get: account_json) }
 
     before do
       allow(subject).to receive(:access_token).and_return(access_token)
@@ -31,6 +42,15 @@ describe OmniAuth::Strategies::Digitalocean do
     describe "#uid" do
       it "returns uuid from the info hash" do
         expect(subject.uid).to eq(uuid)
+      end
+    end
+
+    describe '#extra' do
+      it 'includes the information returned from the account endpoint' do
+        expect(subject.extra['droplet_limit']).to eq(25)
+        expect(subject.extra['email']).to eq("foo@example.com")
+        expect(subject.extra['uuid']).to eq("b6fc48dbf6d990634ce5f3c78dc9851e757381ef")
+        expect(subject.extra['email_verified']).to eq(true)
       end
     end
   end


### PR DESCRIPTION
This is a rebase of https://github.com/digitalocean/omniauth-digitalocean/pull/4 to hit the DO API's `v2/account` endpoint to get additional data about the user. Updated to not specify the individual keys, but return all the info from the account.

cc @nanzhong 
