### PR TITLE
Use string as provider name instead of symbol

### DIFF
--- a/lib/omniauth/strategies/digitalocean.rb
+++ b/lib/omniauth/strategies/digitalocean.rb
@@ -12,7 +12,7 @@ module OmniAuth
       AUTHENTICATION_PARAMETERS = %w(display state scope)
       BASE_URL = "https://cloud.digitalocean.com"
 
-      option :name, :digitalocean
+      option :name, "digitalocean"
 
       unless OmniAuth.config.test_mode
         option :client_options, {

--- a/spec/omniauth/strategies/digitalocean_spec.rb
+++ b/spec/omniauth/strategies/digitalocean_spec.rb
@@ -6,7 +6,7 @@ describe OmniAuth::Strategies::Digitalocean do
   end
 
   describe "production client options" do
-    it { expect(subject.options.name).to eq(:digitalocean) }
+    it { expect(subject.options.name).to eq("digitalocean") }
 
     it { expect(subject.options.client_options.site).to eq("https://cloud.digitalocean.com") }
     it { expect(subject.options.client_options.authorize_url).to eq("https://cloud.digitalocean.com/v1/oauth/authorize") }


### PR DESCRIPTION
Usage of the symbol is inconsistent with other providers, and also results in bugs where `auth_hash[:provider]` must be converted to a string via `.to_s` if used in a `case`, for example.