### PR TITLE
Allow context parameter to be sent with strategy

### DIFF
--- a/lib/omniauth-digitalocean/version.rb
+++ b/lib/omniauth-digitalocean/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Digitalocean
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/omniauth/strategies/digitalocean.rb
+++ b/lib/omniauth/strategies/digitalocean.rb
@@ -9,7 +9,7 @@ module OmniAuth
     #    use OmniAuth::Strategies::Digitalocean, 'consumerkey', 'consumersecret', :scope => 'read write', :display => 'plain'
     #
     class Digitalocean < OmniAuth::Strategies::OAuth2
-      AUTHENTICATION_PARAMETERS = %w(display state scope)
+      AUTHENTICATION_PARAMETERS = %w(display account state scope)
       BASE_URL = "https://cloud.digitalocean.com"
 
       option :name, "digitalocean"


### PR DESCRIPTION
This allows the `account` parameter for oauth authorization.

cc @phillbaker 