### PR TITLE
Update strategy to populate "extra" field

### DIFF
--- a/lib/omniauth/strategies/digitalocean.rb
+++ b/lib/omniauth/strategies/digitalocean.rb
@@ -11,6 +11,7 @@ module OmniAuth
     class Digitalocean < OmniAuth::Strategies::OAuth2
       AUTHENTICATION_PARAMETERS = %w(display account state scope)
       BASE_URL = "https://cloud.digitalocean.com"
+      API_URL = "https://api.digitalocean.com"
 
       option :name, "digitalocean"
 
@@ -29,6 +30,10 @@ module OmniAuth
       end
 
       option :authorize_options, AUTHENTICATION_PARAMETERS
+
+      extra do
+        raw_info.parsed['account']
+      end
 
       uid do
         access_token.params['info']['uuid']
@@ -56,6 +61,10 @@ module OmniAuth
       # request from provider.
       def callback_phase
         super
+      end
+
+      def raw_info
+        @raw_info ||= access_token.get("#{API_URL}/v2/account")
       end
 
       ##

--- a/spec/omniauth/strategies/digitalocean_spec.rb
+++ b/spec/omniauth/strategies/digitalocean_spec.rb
@@ -22,7 +22,18 @@ describe OmniAuth::Strategies::Digitalocean do
         }
       }
     }
-    let(:access_token) { double('AccessToken', params: response_params) }
+    let(:account_response) {
+      { 'account' =>
+        {
+          'droplet_limit' => 25,
+          'email' => 'foo@example.com',
+          'uuid' => 'b6fc48dbf6d990634ce5f3c78dc9851e757381ef',
+          'email_verified' => true
+        }
+      }
+    }
+    let(:account_json) { double(:json, parsed: account_response) }
+    let(:access_token) { double('AccessToken', params: response_params, get: account_json) }
 
     before do
       allow(subject).to receive(:access_token).and_return(access_token)
@@ -31,6 +42,15 @@ describe OmniAuth::Strategies::Digitalocean do
     describe "#uid" do
       it "returns uuid from the info hash" do
         expect(subject.uid).to eq(uuid)
+      end
+    end
+
+    describe '#extra' do
+      it 'includes the information returned from the account endpoint' do
+        expect(subject.extra['droplet_limit']).to eq(25)
+        expect(subject.extra['email']).to eq("foo@example.com")
+        expect(subject.extra['uuid']).to eq("b6fc48dbf6d990634ce5f3c78dc9851e757381ef")
+        expect(subject.extra['email_verified']).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Based on #7

Updates the strategy to populate the [`extra`](https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema#schema-10-and-later) field based on the response from the [Account API endpoint](https://api.digitaloean.com/v2/account).

I tested this locally as well using the Sinatra example with my personal account, and it appears to work:

```
{"provider"=>"digitalocean", "uid"=>"445358553eac217ce8be3f6547112b0f4ba5b31d", "info"=>{"name"=>"Ben Tranter", "email"=>"redacted-so-bots-dont-email-me@example.com", "uuid"=>"a45358553eac217ce8be3f6547112b0f4ba5b31d"}, "credentials"=>{"token"=>"<redacted>", "refresh_token"=>"<redacted>", "expires_at"=>1613939120, "expires"=>true}, "extra"=>{"droplet_limit"=>25, "floating_ip_limit"=>3, "volume_limit"=>100, "email"=>"redacted-so-bots-dont-email-me@example.com", "uuid"=>"a45358553eac217ce8be3f6547112b0f4ba5b31d", "email_verified"=>true, "status"=>"active", "status_message"=>""}}
```