### PR TITLE
Prep 0.3.0 release.

### DIFF
--- a/lib/omniauth-digitalocean/version.rb
+++ b/lib/omniauth-digitalocean/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Digitalocean
-    VERSION = "0.2.1"
+    VERSION = "0.3.0"
   end
 end

--- a/omniauth-digitalocean.gemspec
+++ b/omniauth-digitalocean.gemspec
@@ -5,11 +5,11 @@ require 'omniauth-digitalocean/version'
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-digitalocean"
   spec.version       = Omniauth::Digitalocean::VERSION
-  spec.authors       = ["Phillip Baker"]
-  spec.email         = ["phillip@digitalocean.com"]
+  spec.authors       = ["DigitalOcean API Engineering team"]
+  spec.email         = ["api-engineering@digitalocean.com"]
   spec.summary       = %q{Official OmniAuth strategy for Digitalocean}
   spec.description   = %q{Official OmniAuth strategy for Digitalocean}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/digitalocean/omniauth-digitalocean"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Once https://github.com/digitalocean/omniauth-digitalocean/pull/17 lands, we can cut a new release.