### PR TITLE
Support Omniauth 2.0

### DIFF
--- a/omniauth-digitalocean.gemspec
+++ b/omniauth-digitalocean.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "omniauth", "~> 1.0"
+  spec.add_dependency "omniauth", "~> 2.0"
   spec.add_dependency "omniauth-oauth2", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
This updates the OmniAuth dependency to 2.0 which fixes [security issues](https://nvd.nist.gov/vuln/detail/CVE-2015-9284) with 1.x. 

https://github.com/omniauth/omniauth/releases/tag/v2.0.0