### PR TITLE
Update Sinatra example for omniauth 2.0

### DIFF
--- a/examples/sinatra/Gemfile
+++ b/examples/sinatra/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
-gem 'omniauth'
+gem 'omniauth', "~> 2.0"
 gem 'omniauth-digitalocean', :path => '../../'
 gem 'multi_json'

--- a/examples/sinatra/Gemfile
+++ b/examples/sinatra/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
-gem 'omniauth', "~> 2.0"
+gem 'omniauth', '~> 2.0'
 gem 'omniauth-digitalocean', :path => '../../'
 gem 'multi_json'

--- a/examples/sinatra/README.md
+++ b/examples/sinatra/README.md
@@ -1,7 +1,17 @@
 # Sinatra Example
 
-How to use omniauth-digitalocean strategy with Sinatra.
+A simple example of how to use `omniauth-digitalocean` strategy with Sinatra.
 
 ## Setup
 
-Create an application on http://cloud.digitalocean.com/settings/application and set the ENV variables DIGITALOCEAN_APP_ID and DIGITALOCEAN_SECRET.
+Create an OAuth application in the [DigitalOcean control panel](https://cloud.digitalocean.com/account/api/applications).
+The callback URL should be `http://127.0.0.1:4567/auth/digitalocean/callback`.
+
+Next, set the environment variables `DIGITALOCEAN_APP_ID`
+and `DIGITALOCEAN_SECRET` with the values from the control panel. Then run the
+app with:
+
+    bundle install
+    bundle exec ruby config.ru
+
+Now visit `http://127.0.0.1:4567` in the browser to login via DigitalOcean.

--- a/examples/sinatra/config.ru
+++ b/examples/sinatra/config.ru
@@ -7,7 +7,12 @@ class DigitalOceanExample < Sinatra::Base
   use Rack::Session::Cookie
 
   get '/' do
-    redirect '/auth/digitalocean'
+    <<~HTML
+      <form method='post' action='/auth/digitalocean'>
+        <input type="hidden" name="authenticity_token" value='#{request.env["rack.session"]["csrf"]}'>
+        <button type='submit'>Login with DigitalOcean</button>
+      </form>
+    HTML
   end
 
   get '/auth/:provider/callback' do


### PR DESCRIPTION
This updates the Sinatra example for omniauth 2.0 and makes its README a bit more useful.

See: "OmniAuth now defaults to only POST as the allowed request_phase method."

https://github.com/omniauth/omniauth/releases/tag/v2.0.0
