### PR TITLE
GH action: simplify ruby bundler caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,25 +12,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ruby: [ 2.5, 2.6, 2.7 ]
+        ruby: [ 2.5, 2.6, 2.7, 3.0 ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
 
-    # Cache dependencies.
-    - uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-
-    - name: Setup
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
     - name: Test
       run: |
         bundle exec rspec ./spec

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,18 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
-
-    - uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: bundle-use-ruby-ubuntu-latest-2.6-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          bundle-use-ruby-ubuntu-latest-2.6-
+        ruby-version: 2.7
 
     - name: Publish to RubyGems
       run: |


### PR DESCRIPTION
- Use GH action [ruby/setup-ruby build in bundler caching support](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically) for handling bundler install and caching.
- Minor `actions/checkout` version bump.