### PR TITLE
Specify `auth_scheme: :request_body` for oauth2 v2.x compatibility

### DIFF
--- a/lib/omniauth/strategies/digitalocean.rb
+++ b/lib/omniauth/strategies/digitalocean.rb
@@ -19,13 +19,15 @@ module OmniAuth
         option :client_options, {
           :authorize_url => "#{BASE_URL}/v1/oauth/authorize",
           :token_url => "#{BASE_URL}/v1/oauth/token",
-          :site => BASE_URL
+          :site => BASE_URL,
+          :auth_scheme => :request_body
         }
       else
         option :client_options, {
           :authorize_url => "http://localhost:3000/v1/oauth/authorize",
           :token_url => "http://localhost:3000/v1/oauth/token",
-          :site => "http://localhost:3000"
+          :site => "http://localhost:3000",
+          :auth_scheme => :request_body
         }
       end
 


### PR DESCRIPTION
The oauth2 gem switched the default auth_scheme in v2 from `:request_body` to `:basic_auth`. This caused an "Invalid Credentials" error when requesting the auth token because client_id and client_secret params were not included in the requests.

This is a backwards compatible change that will work with oauth2 v1.x and v2.x.

https://gitlab.com/oauth-xx/oauth2/-/blob/v1.4.11/lib/oauth2/client.rb?ref_type=tags#L44 
https://gitlab.com/oauth-xx/oauth2/-/blob/v2.0.0/lib/oauth2/client.rb?ref_type=tags#L46

For anyone curious, the `auth_scheme` determines how the authentication params or headers are included in the token request. Since this is now `basic_auth` unless specified, the `client_id` and `client_secret` were not included in params. https://gitlab.com/oauth-xx/oauth2/-/blob/v2.0.9/lib/oauth2/authenticator.rb?ref_type=tags#L24

Fixes #25 