### PR TITLE
Add explicit dependency on multi_json

### DIFF
--- a/omniauth-digitalocean.gemspec
+++ b/omniauth-digitalocean.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "omniauth", "~> 2.0"
   spec.add_dependency "omniauth-oauth2", "~> 1.0"
+  spec.add_dependency "multi_json", '~> 1.15'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This adds an explicit dependency on `multi_json` to resolve the test failures seen in https://github.com/digitalocean/omniauth-digitalocean/pull/26

e.g. https://github.com/digitalocean/omniauth-digitalocean/actions/runs/5014811074/jobs/8989545917?pr=26